### PR TITLE
Version 2.0.0-rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [v2.0.0-rc1] - WebForms API v1.1.0-1.0.4 - 2024-09-24
+### Changed
+- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
+- Updated the SDK release version.
+
+### Breaking changes
+- Substituted the Superagent proxy with Axios 1.6.8, addressing security vulnerabilities.
+
+## Important Action Required
+- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
 ## [v1.0.0] - WebForms API v1.1.0-1.0.2 - 2024-02-14
 ## Version 1.0.0 (Initial Release)
 - Introducing the SDK based on the OpenAPI specification of DocuSign WebForms APIs.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusign-webforms",
-  "version": "1.0.2-rc12",
-  "description": "DocuSign Node.js API client.",
+  "version": "2.0.0-rc1",
+  "description": "Docusign Node.js API client.",
   "license": "MIT",
   "main": "src/index.js",
   "author": "DocuSign Developer Center <devcenter@docusign.com>",
@@ -64,6 +64,7 @@
     "jsdoc": "3.6.10",
     "mocha": "~5.0.4",
     "mocha-junit-reporter": "^1.18.0",
+    "pdf-parse-fork": "^1.2.0",
     "semistandard": "^12.0.1"
   }
 }

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -187,7 +187,7 @@
    */
   var exports = function (opts) {
     var defaults = {
-      basePath: "https://apps-d.docusign.com/api/webforms/v1.1",
+      basePath: "https://apps-d.docusign.com/api/webforms",
       oAuthBasePath: require("./OAuth").BasePath.PRODUCTION,
     };
 
@@ -205,14 +205,14 @@
     /**
      * The base URL against which to resolve every API call's (relative) path.
      * @type {String}
-     * @default https://apps-d.docusign.com/api/webforms/v1.1
+     * @default https://apps-d.docusign.com/api/webforms
      */
     this.basePath = opts.basePath;
 
     /**
      * The base URL against which to resolve every authentication API call's (relative) path.
      * @type {String}
-     * @default https://apps-d.docusign.com/api/webforms/v1.1
+     * @default https://apps-d.docusign.com/api/webforms
      */
     this.oAuthBasePath = opts.oAuthBasePath;
 
@@ -279,6 +279,16 @@
     value
   ) {
     defaultHeaders[header] = value;
+  };
+
+  /**
+   * Sets default JWT authorization token for APIs.
+   */
+  exports.prototype.setJWTToken = function setJWTToken(token) {
+    if(!token){
+      throw new Error("Missing the required parameter 'token' when calling setJWTToken.");
+    }
+    defaultHeaders["Authorization"] = `Bearer ${token}`;
   };
 
   /**

--- a/src/RestApi.js
+++ b/src/RestApi.js
@@ -1,6 +1,6 @@
-const PRODUCTION_BASE_PATH = 'https://us.services.docusign.net/webforms/v1.1';
-const DEMO_BASE_PATH = 'https://apps-d.docusign.com/api/webforms/v1.1';
-const STAGE_BASE_PATH = 'https://apps-s.docusign.com/api/webforms/v1.1';
+const PRODUCTION_BASE_PATH = 'https://us.services.docusign.net/webforms';
+const DEMO_BASE_PATH = 'https://apps-d.docusign.com/api/webforms';
+const STAGE_BASE_PATH = 'https://apps-s.docusign.com/api/webforms';
 
 module.exports = {
   BasePath: {

--- a/src/api/FormInstanceManagementApi.js
+++ b/src/api/FormInstanceManagementApi.js
@@ -110,7 +110,7 @@
       var returnType = WebFormInstance;
 
       return this.apiClient.callApi(
-        '/accounts/{accountId}/forms/{formId}/instances', 'POST',
+        '/v1.1/accounts/{accountId}/forms/{formId}/instances', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
@@ -176,7 +176,7 @@
       var returnType = WebFormInstance;
 
       return this.apiClient.callApi(
-        '/accounts/{accountId}/forms/{formId}/instances/{instanceId}', 'GET',
+        '/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
@@ -245,7 +245,7 @@
       var returnType = WebFormInstanceList;
 
       return this.apiClient.callApi(
-        '/accounts/{accountId}/forms/{formId}/instances', 'GET',
+        '/v1.1/accounts/{accountId}/forms/{formId}/instances', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
@@ -311,7 +311,7 @@
       var returnType = WebFormInstance;
 
       return this.apiClient.callApi(
-        '/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh', 'POST',
+        '/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );

--- a/src/api/FormManagementApi.js
+++ b/src/api/FormManagementApi.js
@@ -114,7 +114,7 @@
       var returnType = WebForm;
 
       return this.apiClient.callApi(
-        '/accounts/{accountId}/forms/{formId}', 'GET',
+        '/v1.1/accounts/{accountId}/forms/{formId}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
@@ -188,7 +188,7 @@
       var returnType = WebFormSummaryList;
 
       return this.apiClient.callApi(
-        '/accounts/{accountId}/forms', 'GET',
+        '/v1.1/accounts/{accountId}/forms', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );

--- a/src/index.js
+++ b/src/index.js
@@ -11,16 +11,16 @@
 (function(factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['Configuration', 'ApiClient', 'model/AuthenticationMethod', 'model/CreateInstanceRequestBody', 'model/HttpError', 'model/HttpSuccess', 'model/InstanceSource', 'model/InstanceStatus', 'model/TemplateProperties', 'model/WebForm', 'model/WebFormComponentType', 'model/WebFormContent', 'model/WebFormInstance', 'model/WebFormInstanceEnvelopes', 'model/WebFormInstanceList', 'model/WebFormInstanceMetadata', 'model/WebFormMetadata', 'model/WebFormProperties', 'model/WebFormSource', 'model/WebFormState', 'model/WebFormSummary', 'model/WebFormSummaryList', 'model/WebFormUserInfo', 'model/WebFormValues', 'api/FormInstanceManagementApi', 'api/FormManagementApi'], factory);
+    define(['Configuration', 'ApiClient', 'model/AuthenticationMethod', 'model/CreateInstanceRequestBody', 'model/HttpError', 'model/HttpSuccess', 'model/InstanceSource', 'model/InstanceStatus', 'model/TemplateProperties', 'model/WebForm', 'model/WebFormComponentType', 'model/WebFormContent', 'model/WebFormInstance', 'model/WebFormInstanceEnvelopes', 'model/WebFormInstanceList', 'model/WebFormInstanceMetadata', 'model/WebFormMetadata', 'model/WebFormProperties', 'model/WebFormSource', 'model/WebFormState', 'model/WebFormSummary', 'model/WebFormSummaryList', 'model/WebFormType', 'model/WebFormUserInfo', 'model/WebFormValues', 'api/FormInstanceManagementApi', 'api/FormManagementApi'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('./Configuration'), require('./ApiClient'), require('./model/AuthenticationMethod'), require('./model/CreateInstanceRequestBody'), require('./model/HttpError'), require('./model/HttpSuccess'), require('./model/InstanceSource'), require('./model/InstanceStatus'), require('./model/TemplateProperties'), require('./model/WebForm'), require('./model/WebFormComponentType'), require('./model/WebFormContent'), require('./model/WebFormInstance'), require('./model/WebFormInstanceEnvelopes'), require('./model/WebFormInstanceList'), require('./model/WebFormInstanceMetadata'), require('./model/WebFormMetadata'), require('./model/WebFormProperties'), require('./model/WebFormSource'), require('./model/WebFormState'), require('./model/WebFormSummary'), require('./model/WebFormSummaryList'), require('./model/WebFormUserInfo'), require('./model/WebFormValues'), require('./api/FormInstanceManagementApi'), require('./api/FormManagementApi'));
+    module.exports = factory(require('./Configuration'), require('./ApiClient'), require('./model/AuthenticationMethod'), require('./model/CreateInstanceRequestBody'), require('./model/HttpError'), require('./model/HttpSuccess'), require('./model/InstanceSource'), require('./model/InstanceStatus'), require('./model/TemplateProperties'), require('./model/WebForm'), require('./model/WebFormComponentType'), require('./model/WebFormContent'), require('./model/WebFormInstance'), require('./model/WebFormInstanceEnvelopes'), require('./model/WebFormInstanceList'), require('./model/WebFormInstanceMetadata'), require('./model/WebFormMetadata'), require('./model/WebFormProperties'), require('./model/WebFormSource'), require('./model/WebFormState'), require('./model/WebFormSummary'), require('./model/WebFormSummaryList'), require('./model/WebFormType'), require('./model/WebFormUserInfo'), require('./model/WebFormValues'), require('./api/FormInstanceManagementApi'), require('./api/FormManagementApi'));
   }
-}(function(Configuration, ApiClient, AuthenticationMethod, CreateInstanceRequestBody, HttpError, HttpSuccess, InstanceSource, InstanceStatus, TemplateProperties, WebForm, WebFormComponentType, WebFormContent, WebFormInstance, WebFormInstanceEnvelopes, WebFormInstanceList, WebFormInstanceMetadata, WebFormMetadata, WebFormProperties, WebFormSource, WebFormState, WebFormSummary, WebFormSummaryList, WebFormUserInfo, WebFormValues, FormInstanceManagementApi, FormManagementApi) {
+}(function(Configuration, ApiClient, AuthenticationMethod, CreateInstanceRequestBody, HttpError, HttpSuccess, InstanceSource, InstanceStatus, TemplateProperties, WebForm, WebFormComponentType, WebFormContent, WebFormInstance, WebFormInstanceEnvelopes, WebFormInstanceList, WebFormInstanceMetadata, WebFormMetadata, WebFormProperties, WebFormSource, WebFormState, WebFormSummary, WebFormSummaryList, WebFormType, WebFormUserInfo, WebFormValues, FormInstanceManagementApi, FormManagementApi) {
   'use strict';
 
   /**
-   * DocuSign Node.js API client..<br>
+   * Docusign Node.js API client..<br>
    * The <code>index</code> module provides access to constructors for all the classes which comprise the public API.
    * <p>
    * An AMD (recommended!) or CommonJS application will generally do something equivalent to the following:
@@ -160,6 +160,11 @@
      * @property {module:model/WebFormSummaryList}
      */
     WebFormSummaryList: WebFormSummaryList,
+    /**
+     * The WebFormType model constructor.
+     * @property {module:model/WebFormType}
+     */
+    WebFormType: WebFormType,
     /**
      * The WebFormUserInfo model constructor.
      * @property {module:model/WebFormUserInfo}

--- a/src/model/AccountId.js
+++ b/src/model/AccountId.js
@@ -34,7 +34,7 @@
 
   /**
    * Constructs a new <code>AccountId</code>.
-   * Account identifier in which the webform resides
+   * Account identifier in which the web form resides
    * @alias module:model/AccountId
    * @class
    */

--- a/src/model/CreatedDateTime.js
+++ b/src/model/CreatedDateTime.js
@@ -34,7 +34,7 @@
 
   /**
    * Constructs a new <code>CreatedDateTime</code>.
-   * The dateTime when the webform instance is created.
+   * The dateTime when the Web Form Instance is created.
    * @alias module:model/CreatedDateTime
    * @class
    */

--- a/src/model/ExpirationDateTime.js
+++ b/src/model/ExpirationDateTime.js
@@ -34,7 +34,7 @@
 
   /**
    * Constructs a new <code>ExpirationDateTime</code>.
-   * The datetime after which the webform instance is inaccessible.
+   * The datetime after which the Web Form Instance is inaccessible.
    * @alias module:model/ExpirationDateTime
    * @class
    */

--- a/src/model/FormUrl.js
+++ b/src/model/FormUrl.js
@@ -34,7 +34,7 @@
 
   /**
    * Constructs a new <code>FormUrl</code>.
-   * The instance url which can be rendered by the user
+   * The url used to render the web form instance.
    * @alias module:model/FormUrl
    * @class
    */

--- a/src/model/InstanceId.js
+++ b/src/model/InstanceId.js
@@ -34,7 +34,7 @@
 
   /**
    * Constructs a new <code>InstanceId</code>.
-   * Unique identifier for a webform instance that is consistent until its expiration
+   * Unique identifier for a Web Form Instance that is consistent until its expiration
    * @alias module:model/InstanceId
    * @class
    */

--- a/src/model/InstanceSource.js
+++ b/src/model/InstanceSource.js
@@ -51,7 +51,12 @@
      * value: "UI_REMOTE"
      * @const
      */
-    "UI_REMOTE": "UI_REMOTE"  };
+    "UI_REMOTE": "UI_REMOTE",
+    /**
+     * value: "WORKFLOW"
+     * @const
+     */
+    "WORKFLOW": "WORKFLOW"  };
 
   /**
    * Returns a <code>InstanceSource</code> enum value from a Javascript object name.

--- a/src/model/UserId.js
+++ b/src/model/UserId.js
@@ -34,7 +34,7 @@
 
   /**
    * Constructs a new <code>UserId</code>.
-   * DocuSign user identifier
+   * DocuSign User identifier
    * @alias module:model/UserId
    * @class
    */

--- a/src/model/WebFormId.js
+++ b/src/model/WebFormId.js
@@ -34,7 +34,7 @@
 
   /**
    * Constructs a new <code>WebFormId</code>.
-   * Unique identifier for a webform entity that is consistent for it's lifetime
+   * Unique identifier for a Web Form that is consistent for it's lifetime
    * @alias module:model/WebFormId
    * @class
    */

--- a/src/model/WebFormMetadata.js
+++ b/src/model/WebFormMetadata.js
@@ -12,18 +12,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient', 'model/WebFormComponentType', 'model/WebFormSource', 'model/WebFormUserInfo'], factory);
+    define(['ApiClient', 'model/WebFormComponentType', 'model/WebFormSource', 'model/WebFormType', 'model/WebFormUserInfo'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../ApiClient'), require('./WebFormComponentType'), require('./WebFormSource'), require('./WebFormUserInfo'));
+    module.exports = factory(require('../ApiClient'), require('./WebFormComponentType'), require('./WebFormSource'), require('./WebFormType'), require('./WebFormUserInfo'));
   } else {
     // Browser globals (root is window)
     if (!root.Docusign) {
       root.Docusign = {};
     }
-    root.Docusign.WebFormMetadata = factory(root.Docusign.ApiClient, root.Docusign.WebFormComponentType, root.Docusign.WebFormSource, root.Docusign.WebFormUserInfo);
+    root.Docusign.WebFormMetadata = factory(root.Docusign.ApiClient, root.Docusign.WebFormComponentType, root.Docusign.WebFormSource, root.Docusign.WebFormType, root.Docusign.WebFormUserInfo);
   }
-}(this, function(ApiClient, WebFormComponentType, WebFormSource, WebFormUserInfo) {
+}(this, function(ApiClient, WebFormComponentType, WebFormSource, WebFormType, WebFormUserInfo) {
   'use strict';
 
 
@@ -57,6 +57,12 @@
 
       if (data.hasOwnProperty('source')) {
         obj['source'] = WebFormSource.constructFromObject(data['source']);
+      }
+      if (data.hasOwnProperty('type')) {
+        obj['type'] = WebFormType.constructFromObject(data['type']);
+      }
+      if (data.hasOwnProperty('sourceFormId')) {
+        obj['sourceFormId'] = ApiClient.convertToType(data['sourceFormId'], 'String');
       }
       if (data.hasOwnProperty('owner')) {
         obj['owner'] = WebFormUserInfo.constructFromObject(data['owner']);
@@ -120,10 +126,20 @@
   }
 
   /**
-   * The source from which the webform is created. Accepted values are [upload, templates, blank]
+   * The source from which the webform is created. Accepted values are [templates, blank, form]
    * @member {module:model/WebFormSource} source
    */
   exports.prototype['source'] = undefined;
+  /**
+   * Represents webform type. Possible values are [standalone, hasEsignTemplate]
+   * @member {module:model/WebFormType} type
+   */
+  exports.prototype['type'] = undefined;
+  /**
+   * The source form id from which the webform is created.
+   * @member {String} sourceFormId
+   */
+  exports.prototype['sourceFormId'] = undefined;
   /**
    * The user that created the form or has been transferred ownership
    * @member {module:model/WebFormUserInfo} owner

--- a/src/model/WebFormSource.js
+++ b/src/model/WebFormSource.js
@@ -41,7 +41,12 @@
      * value: "blank"
      * @const
      */
-    "blank": "blank"  };
+    "blank": "blank",
+    /**
+     * value: "form"
+     * @const
+     */
+    "form": "form"  };
 
   /**
    * Returns a <code>WebFormSource</code> enum value from a Javascript object name.

--- a/src/model/WebFormSummary.js
+++ b/src/model/WebFormSummary.js
@@ -67,6 +67,9 @@
       if (data.hasOwnProperty('isEnabled')) {
         obj['isEnabled'] = ApiClient.convertToType(data['isEnabled'], 'Boolean');
       }
+      if (data.hasOwnProperty('isUploaded')) {
+        obj['isUploaded'] = ApiClient.convertToType(data['isUploaded'], 'Boolean');
+      }
       if (data.hasOwnProperty('hasDraftChanges')) {
         obj['hasDraftChanges'] = ApiClient.convertToType(data['hasDraftChanges'], 'Boolean');
       }
@@ -101,6 +104,11 @@
    * @member {Boolean} isEnabled
    */
   exports.prototype['isEnabled'] = undefined;
+  /**
+   * Has the form created through upload
+   * @member {Boolean} isUploaded
+   */
+  exports.prototype['isUploaded'] = undefined;
   /**
    * Does the form have draft changes that need to be published?
    * @member {Boolean} hasDraftChanges

--- a/src/model/WebFormType.js
+++ b/src/model/WebFormType.js
@@ -21,47 +21,32 @@
     if (!root.Docusign) {
       root.Docusign = {};
     }
-    root.Docusign.InstanceStatus = factory(root.Docusign.ApiClient);
+    root.Docusign.WebFormType = factory(root.Docusign.ApiClient);
   }
 }(this, function(ApiClient) {
   'use strict';
 
   /**
-   * Enum class InstanceStatus.
+   * Enum class WebFormType.
    * @enum {}
    * @readonly
    */
   var exports = {
     /**
-     * value: "INITIATED"
+     * value: "standalone"
      * @const
      */
-    "INITIATED": "INITIATED",
+    "standalone": "standalone",
     /**
-     * value: "IN_PROGRESS"
+     * value: "hasEsignTemplate"
      * @const
      */
-    "IN_PROGRESS": "IN_PROGRESS",
-    /**
-     * value: "SUBMITTED"
-     * @const
-     */
-    "SUBMITTED": "SUBMITTED",
-    /**
-     * value: "EXPIRED"
-     * @const
-     */
-    "EXPIRED": "EXPIRED",
-    /**
-     * value: "FAILED"
-     * @const
-     */
-    "FAILED": "FAILED"  };
+    "hasEsignTemplate": "hasEsignTemplate"  };
 
   /**
-   * Returns a <code>InstanceStatus</code> enum value from a Javascript object name.
+   * Returns a <code>WebFormType</code> enum value from a Javascript object name.
    * @param {Object} data The plain JavaScript object containing the name of the enum value.
-   * @return {module:model/InstanceStatus} The enum <code>InstanceStatus</code> value.
+   * @return {module:model/WebFormType} The enum <code>WebFormType</code> value.
    */
   exports.constructFromObject = function(object) {
     return object;

--- a/test/FormManagementApiIntegrationTest.js
+++ b/test/FormManagementApiIntegrationTest.js
@@ -44,6 +44,9 @@ describe('FormManagementApi tests:', () => {
           [],
           'Ensure that the items is not an empty array.'
         );
+
+        const item = items.find(each => each.formState === 'active');
+
         const {
           id,
           accountId,
@@ -53,7 +56,7 @@ describe('FormManagementApi tests:', () => {
           formState,
           formProperties,
           formMetadata
-        } = items[0];
+        } = item || {};
         assert.notStrictEqual(
           id,
           undefined,

--- a/test/SdkUnitTests.js
+++ b/test/SdkUnitTests.js
@@ -65,7 +65,7 @@ describe('SDK Unit Tests:', function (done) {
       .then(function (res) {
         let baseUri,
           accountDomain;
-        apiClient.addDefaultHeader('Authorization', 'Bearer ' + res.body.access_token);
+        apiClient.setJWTToken(res.body.access_token);
 
         apiClient.getUserInfo(res.body.access_token)
           .then(function (userInfo) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,7 +12,7 @@ const {
   EXPIRES_IN,
   apiClient,
   scopes
- } = constants || {};
+} = constants || {};
 
 const JWTAuth = () => {
   return new Promise(function (resolve, reject) {
@@ -26,7 +26,7 @@ const JWTAuth = () => {
         OAUTH_BASE_PATH
       );
       // open DocuSign OAuth authorization url in the browser, login and grant access
-      console.log("OAuth authorization url:", authorizationUrl);
+      console.log('OAuth authorization url:', authorizationUrl);
       const privateKeyFile = fs.readFileSync(
         path.resolve(__dirname, PRIVATE_KEY_FILENAME)
       );
@@ -39,17 +39,14 @@ const JWTAuth = () => {
           EXPIRES_IN
         )
         .then(function (res) {
-          apiClient.addDefaultHeader(
-            "Authorization",
-            `Bearer ${res.body.access_token}`
-          );
+          apiClient.setJWTToken(res.body.access_token);
 
           apiClient
             .getUserInfo(res.body.access_token)
             .then(function (userInfo) {
               const ACCOUNT_ID = userInfo.accounts[0].accountId;
               apiClient.setBasePath(
-                `https://demo.services.docusign.net/webforms/v1.1`
+                `https://demo.services.docusign.net/webforms`
               );
               return resolve({ apiClient, ACCOUNT_ID });
             })


### PR DESCRIPTION
### Changed
- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
- Updated the SDK release version.

### Breaking changes
- Substituted the Superagent proxy with Axios 1.6.8, addressing security vulnerabilities.

## Important Action Required
- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
